### PR TITLE
Fix long closing tag names

### DIFF
--- a/rxml/Cargo.toml
+++ b/rxml/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/fuzz", "/util", "/target"]
 
 [dependencies]
 weak-table = { version = "^0.3", optional = true }
-smartstring = { version = "^0.2" }
+smartstring = { version = "^1" }
 rxml_validation = { version = "^0.8.0" }
 tokio = { version = "^1", features = ["io-util"], optional = true }
 bytes = { version = "^1" }

--- a/rxml/src/tests.rs
+++ b/rxml/src/tests.rs
@@ -6,6 +6,19 @@ use std::convert::TryFrom;
 use tokio;
 
 #[test]
+fn long_element_names() {
+	let doc = b"<jitsi_participant_codecType>vp9</jitsi_participant_codecType>";
+
+	let mut fp = FeedParser::default();
+	let mut out = Vec::<ResolvedEvent>::new();
+	let mut doc_buf = &doc[..];
+	let result = as_eof_flag(fp.parse_all(&mut doc_buf, false, |ev| {
+		out.push(ev);
+	}));
+	result.unwrap();
+}
+
+#[test]
 fn restricted_xml_for_xml_stylesheet() {
 	let doc = b"<?xml version='1.0'?>\n<?xml-stylesheet?>";
 


### PR DESCRIPTION
This was causing gst-meet to disconnect when sending a presence, see https://github.com/avstack/gst-meet/issues/64

Only the closing tag was affected, being serialised to garbage instead of to the element name. Updating smartstring seems to fix this issue.